### PR TITLE
generar.sh: Fix invalid option in Busybox's shuf command

### DIFF
--- a/src/generar.sh
+++ b/src/generar.sh
@@ -64,7 +64,7 @@ function descargar_imagenes {
 		[[ $CANT =~ ^[1-9]{1}[0-9]*$ ]] || (echo "$CANT no es un numero valido" && continue)
 		
 		I=1
-		shuf --head-count=$CANT $ASSETS_PATH/nombres.csv | while read LINE	
+		shuf -n $CANT $ASSETS_PATH/nombres.csv | while read LINE
 		do
 			NOMBRE_LIMPIO=$(limpiar_nombre "$LINE")
 


### PR DESCRIPTION
The shuf command provided in the Alpine container is different from the one provided by the usual (and more powerful) bash shell interpreter, which you might find in Ubuntu distros.

Busybox's shuf command (the one provided in this Alpine distro) doesn't have the `--head-count` option, instead we need to use `-n` for the same purpose. Fix this.

Belowyou can find the error reported in the `shuf` command, while running the bash scripts using the `-x` option, so each executed line is printed out:

```
+ shuf --head-count=3 /app/src/../assets/nombres.csv
+ read LINE
shuf: unrecognized option: head-count=3
BusyBox v1.36.1 (2023-06-02 00:42:02 UTC) multi-call binary.

Usage: shuf [-n NUM] [-o FILE] [-z] [FILE | -e [ARG...] | -i L-H]

Randomly permute lines

	-n NUM	Output at most NUM lines
	-o FILE	Write to FILE, not standard output
	-z	NUL terminated output
	-e	Treat ARGs as lines
	-i L-H	Treat numbers L-H as lines
+ break
```